### PR TITLE
Avoid double bundler

### DIFF
--- a/definitions/bundle_install.rb
+++ b/definitions/bundle_install.rb
@@ -1,6 +1,7 @@
 define :bundle_install do
   gem_package 'bundler' do
     version '1.17.3'
+    not_if 'gem which bundler'
   end
 
   # bundle install


### PR DESCRIPTION
What
----------------------
Skip bundler install if its already installed.

Why
----------------------
Avoid multiple versions and wasted cycles.

